### PR TITLE
update package: lodash to 4.17.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,9 +263,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "log4js": {


### PR DESCRIPTION
Running the build, presented with message of "2" high severity vulnerabilites:

```
C:\code\coc-powershell [Add-Snippets ≡ +1 ~1 -0 !]> .\build.ps1                                                                         audited 103 packages in 1.049s                                                                                                          found 2 high severity vulnerabilities                                                                                                     run `npm audit fix` to fix them, or `npm audit` for details                                                                                                                                                                                                                                                                                                                                                              ╭────────────────────────────────────────────────────────────────╮                                                                      │                                                                │                                                                      │      New minor version of npm available! 6.9.0 -> 6.10.2       │                                                                      │   Changelog: https://github.com/npm/cli/releases/tag/v6.10.2   │                                                                      │               Run npm install -g npm to update!                │                                                                      │                                                                │                                                                      ╰────────────────────────────────────────────────────────────────╯                                                                                                                                                                                                                                                                                                                                                   > coc-powershell@0.0.18 compile C:\code\coc-powershell                                                                                  > tsc -p ./                                                                                                                                                                                                                                                                     
```
(not entirely sure why the copy from Windows Terminal didn't work too well... so here's a screen shot:

![image](https://user-images.githubusercontent.com/30301021/61902315-98b8e800-aed6-11e9-8a59-956f3b4421d1.png)


Ran `npm audit fix` and committed the updated package-lock.json