### PR TITLE
bug fix: config is not an instance variable

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -136,7 +136,7 @@ export async function activate(context: ExtensionContext) {
 
     let config = settings.load()
     let pwshPath = config.powerShellExePath
-        ? this.config.powerShellExePath 
+        ? config.powerShellExePath
         : getDefaultPowerShellPath(getPlatformDetails())
 
     // Status bar entry showing PS version


### PR DESCRIPTION
there was a rouge `this` that was causing a null exception. This fixes #62 